### PR TITLE
Remove redundant and unused file.

### DIFF
--- a/arbalet/apps/timeclock/__main.py__
+++ b/arbalet/apps/timeclock/__main.py__
@@ -1,9 +1,0 @@
-import argparse
-from .timeclock import TimeClockApp
-
-parser = argparse.ArgumentParser(description='Display a simple clock. The colour is configurable. The app has been written for a 15x10 screen, and does not scale.')
-parser.add_argument('-t', '--type',
-                    default='darkred',
-                    help="Font's color")
-
-TimeClockApp(parser).start()


### PR DESCRIPTION
This PR fixes the fact that the file `__main.py__` was created as a copy of `__main__.py` in `arbalet/apps/timeclock/`.